### PR TITLE
Support multiple item sources and vertical lists

### DIFF
--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -19,8 +19,8 @@
 
 .grid {
   flex: 1;
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  display: flex;
+  flex-direction: column;
   gap: 1rem;
 }
 
@@ -44,4 +44,9 @@
 
 .quantity {
   margin-top: 0.25rem;
+}
+
+.sources {
+  margin-top: 0.25rem;
+  font-size: 0.875rem;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,23 +6,23 @@ export default function Home() {
       name: "Bone Chips",
       image: "/items/bone_chips.svg",
       quantity: 10,
-      monster: "Decaying Skeleton",
+      sources: ["Decaying Skeleton", "Skeleton Warrior"],
     },
     {
       name: "Spider Silk",
       image: "/items/spider_silk.svg",
       quantity: 5,
-      monster: "Spiderling",
+      sources: ["Spiderling", "Giant Spider"],
     },
     {
       name: "Orc Scalp",
       image: "/items/orc_scalp.svg",
       quantity: 8,
-      monster: "Orc Warrior",
+      sources: ["Orc Warrior", "Orc Centurion"],
     },
   ];
 
-  const monsters = Array.from(new Set(items.map((item) => item.monster)));
+  const monsters = Array.from(new Set(items.flatMap((item) => item.sources)));
 
   return (
     <div className={styles.container}>
@@ -34,6 +34,9 @@ export default function Home() {
               <img src={item.image} alt={item.name} className={styles.image} />
               <div className={styles.name}>{item.name}</div>
               <div className={styles.quantity}>Need: {item.quantity}</div>
+              <div className={styles.sources}>
+                Dropped by: {item.sources.join(", ")}
+              </div>
             </div>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- Allow each item to list multiple drop sources
- Deduplicate monsters across all item sources
- Display item and monster lists vertically side by side

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689947926e608330b7fc1ec36533eb83