### PR TITLE
feat: add interactive item checklist and monster filter

### DIFF
--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -31,22 +31,31 @@
   padding: 1rem;
   text-align: center;
 }
+.itemRow {
+  background-color: rgba(0, 0, 0, 0.6);
+  border: 1px solid #ffd700;
+  border-radius: 8px;
+  padding: 0.5rem;
+  display: grid;
+  grid-template-columns: auto 2rem 1fr auto;
+  align-items: center;
+  gap: 0.5rem;
+}
 
-.image {
-  width: 100%;
-  height: auto;
+.itemImage {
+  width: 2rem;
+  height: 2rem;
+}
+
+.itemName {
+  font-weight: bold;
+}
+
+.itemQuantity {
+  justify-self: end;
 }
 
 .name {
   margin-top: 0.5rem;
   font-weight: bold;
-}
-
-.quantity {
-  margin-top: 0.25rem;
-}
-
-.sources {
-  margin-top: 0.25rem;
-  font-size: 0.875rem;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useState } from "react";
 import styles from "./page.module.css";
 
 export default function Home() {
@@ -22,7 +25,23 @@ export default function Home() {
     },
   ];
 
-  const monsters = Array.from(new Set(items.flatMap((item) => item.sources)));
+  const [checked, setChecked] = useState<string[]>([]);
+
+  const toggleItem = (name: string) => {
+    setChecked((prev) =>
+      prev.includes(name)
+        ? prev.filter((n) => n !== name)
+        : [...prev, name]
+    );
+  };
+
+  const monsters = Array.from(
+    new Set(
+      items
+        .filter((item) => checked.includes(item.name))
+        .flatMap((item) => item.sources)
+    )
+  );
 
   return (
     <div className={styles.container}>
@@ -30,13 +49,19 @@ export default function Home() {
       <div className={styles.grids}>
         <div className={styles.grid}>
           {items.map((item) => (
-            <div key={item.name} className={styles.card}>
-              <img src={item.image} alt={item.name} className={styles.image} />
-              <div className={styles.name}>{item.name}</div>
-              <div className={styles.quantity}>Need: {item.quantity}</div>
-              <div className={styles.sources}>
-                Dropped by: {item.sources.join(", ")}
-              </div>
+            <div key={item.name} className={styles.itemRow}>
+              <input
+                type="checkbox"
+                checked={checked.includes(item.name)}
+                onChange={() => toggleItem(item.name)}
+              />
+              <img
+                src={item.image}
+                alt={item.name}
+                className={styles.itemImage}
+              />
+              <div className={styles.itemName}>{item.name}</div>
+              <div className={styles.itemQuantity}>Need: {item.quantity}</div>
             </div>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- display items as checklist with images and quantities
- filter monsters list based on checked items

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68994ddd7c0c833085b46aa59b8e03cb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - You can now select items with checkboxes; the monsters list updates to show only monsters from selected items.
- Style
  - Redesigned items into compact, bordered rows with improved spacing.
  - Item images use fixed, consistent sizing for a cleaner look.
  - Item names are more prominent; quantities are right-aligned for readability.
- Refactor
  - Replaced the previous card layout with a streamlined row-based layout for faster scanning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->