### PR TITLE
Use grid layout for items and monsters

### DIFF
--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -19,12 +19,13 @@
 
 .grid {
   flex: 1;
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
   gap: 1rem;
+  align-content: start;
 }
 
-.card {
+.monster {
   background-color: rgba(0, 0, 0, 0.6);
   border: 1px solid #ffd700;
   border-radius: 8px;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -67,7 +67,7 @@ export default function Home() {
         </div>
         <div className={styles.grid}>
           {monsters.map((monster) => (
-            <div key={monster} className={styles.card}>
+            <div key={monster} className={styles.monster}>
               <div className={styles.name}>{monster}</div>
             </div>
           ))}


### PR DESCRIPTION
## Summary
- Replace flex-column card layout with CSS grid to show more items and monsters
- Style monster entries for grid display and update page to use new class

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6899551a7cdc8330943e7d0fab1e2cf0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Monster list now uses a responsive grid layout with auto-wrapping columns for better use of screen space across devices.

- Style
  - Updated item styling class name with no visual changes to individual cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->